### PR TITLE
Refactor function for docker

### DIFF
--- a/blabot/docker_io.py
+++ b/blabot/docker_io.py
@@ -1,3 +1,13 @@
+"""
+This module provides the ability to exchange input and output
+with other processes in the docker container
+
+This module controls the input/output of processes in the container from the host PC.
+To realize this function, `DockerRunIO` using `docker run` command and
+`DockerExecIO` using `docker exec` command are available.
+Please use the appropriate class for your purpose.
+"""
+
 import pexpect
 import sys
 import subprocess
@@ -5,60 +15,92 @@ import subprocess
 from .process_io import ProcessIO
 
 
-class DockerProcessIO(ProcessIO):
+class DockerRunIO(ProcessIO):
     """
     This class provides the ability to exchange input and output
-    with other processes in the docker container
+    with other processes in the docker container using `docker run` command.
 
     This class controls the input/output of processes in the container from the host PC.
     Although a docker image must be available on the host PC, this class also has the ability to
     automatically launch containers.
-    If you need to work in the container in advance, do it and detach from the container so that
-    this class can resume it with the docker exec command and set the use_docker_exec argument to
-    False.
+    If you need to work in the container in advance, use `DockerExecIO` class.
     """
 
     def __init__(
             self,
             start_command: str,
             docker_image_name: str,
-            docker_container_name: str = "",
-            use_docker_exec: bool = False,
+            docker_container_name: str,
             remove_container: bool = True,
             prompt: str = "",
             newline: str = ""
     ):
-        if use_docker_exec and docker_container_name == "":
-            raise ValueError("If use_docker_exec is True, docker_container_name must be passed")
-
         super().__init__(start_command, prompt, newline)
         self.docker_image_name = docker_image_name
         self.docker_container_name = docker_container_name
-        self.use_docker_exec = use_docker_exec
         self.remove_container = remove_container
 
     def start(self):
         if self.process:
             raise RuntimeError("Process has already started")
 
-        spawn_command = ""
+        docker_run_command = self._build_command()
 
-        if self.use_docker_exec:
-            docker_exec_command = f"docker exec -it {self.docker_container_name} bash"
-            spawn_command = docker_exec_command
-        else:
-            docker_run_command = "docker run -it"
-            if self.remove_container:
-                docker_run_command += " --rm"
+        self.process = pexpect.spawn(docker_run_command)
+        self.process.logfile = sys.stdout.buffer
 
-            if self.docker_container_name:
-                docker_run_command += f" --name {self.docker_container_name}"
+        # Wait for login to complete
+        assert self.wait_for(r"#"), "Failed to start docker"
 
-            docker_run_command += f" {self.docker_image_name} bash"
-            # e.g.) docker run -it --rm --name testtest nn/iointeract:1.0 bash
-            spawn_command = docker_run_command
+        # Do not use `run_command` method here.
+        # For example, if "> " is assigned to the self.prompt, the log immediately
+        # after login does not contain this.
+        # This self.prompt is for test target process.
+        self.send_command(self.start_command)
 
-        self.process = pexpect.spawn(spawn_command)
+    def _build_command(self):
+        docker_run_command = "docker run -it"
+        if self.remove_container:
+            docker_run_command += " --rm"
+
+        if self.docker_container_name:
+            docker_run_command += f" --name {self.docker_container_name}"
+
+        # e.g.) docker run -it --rm --name test_container nn/example-app:1.0 bash
+        docker_run_command += f" {self.docker_image_name} bash"
+
+        return docker_run_command
+
+
+class DockerExecIO(ProcessIO):
+    """
+    This class provides the ability to exchange input and output
+    with other processes in the docker container using `docker exec` command.
+
+    This class controls the input/output of processes in the container from the host PC.
+    Also, this class assumes that the container is running in advance, so please start it
+    before using this class.
+    """
+
+    def __init__(
+            self,
+            start_command: str,
+            docker_container_name: str,
+            remove_container: bool = True,
+            prompt: str = "",
+            newline: str = ""
+    ):
+        super().__init__(start_command, prompt, newline)
+        self.docker_container_name = docker_container_name
+        self.remove_container = remove_container
+
+    def start(self):
+        if self.process:
+            raise RuntimeError("Process has already started")
+
+        docker_exec_command = f"docker exec -it {self.docker_container_name} bash"
+
+        self.process = pexpect.spawn(docker_exec_command)
         self.process.logfile = sys.stdout.buffer
 
         # Wait for login to complete
@@ -73,13 +115,12 @@ class DockerProcessIO(ProcessIO):
     def stop(self):
         super().stop()
 
-        # Remove docker container if necessary
-        # If `use_docker_exec` is False, the --rm option is added when the docker
-        # container is started.
-        if self.use_docker_exec and self.remove_container:
-            if self.docker_container_name:
-                docker_remove_command = ["docker", "rm", "-f", self.docker_container_name]
-                res_remove = subprocess.run(docker_remove_command, stdout=subprocess.DEVNULL)
-                assert res_remove.returncode == 0, "Failed to remove docker container"
-            else:
-                raise RuntimeError("Container name is lost")
+        if not self.remove_container:
+            return
+
+        if not self.docker_container_name:
+            raise RuntimeError("Container name is lost")
+
+        docker_remove_command = ["docker", "rm", "-f", self.docker_container_name]
+        res_remove = subprocess.run(docker_remove_command, stdout=subprocess.DEVNULL)
+        assert res_remove.returncode == 0, "Failed to remove docker container"

--- a/examples/README.md
+++ b/examples/README.md
@@ -133,13 +133,13 @@ cd ${BLABOT}/examples/
 pytest -v -s -m "ssh_test" tests/
 ```
 
-## DockerProcessIO
+## DockerIO(DockerRunIO + DockerExecIO)
 
 ```mermaid
 graph LR
     subgraph HostPC["Host PC"]
         Software["Software"]
-        DockerIO["DockerProcessIO
+        DockerIO["DockerIO
                   (No need to be
                   in container)"]
     end
@@ -154,9 +154,9 @@ graph LR
                    Receive result"| Software_copied
 ```
 
-A class named `DockerProcessIO` is provided in the file `docker_io.py`.
+`DockerRunIO` and `DockerExecIO` are provided in the file `docker_io.py`.
 
-This class is to run a process in the docker container.
+These classes are to run a process in the docker container.
 
 ```shell
 # Build docker image
@@ -188,7 +188,7 @@ graph LR
 ```
 
 This is for cases where the files of this project have been copied or mounted in a docker container.
-In this case, it is not necessary to use `DockerProcessIO`, but it is sufficient to start up `ProcessIO` in the container.
+In this case, it is not necessary to use `DockerRunIO` or `DockerExecIO`, but it is sufficient to start up `ProcessIO` in the container.
 
 ```shell
 # Build docker image

--- a/examples/tests/test_docker.py
+++ b/examples/tests/test_docker.py
@@ -2,25 +2,26 @@ import pytest
 import subprocess
 
 from cli.example_cli import ExampleCli
-from cli.blabot.blabot.docker_io import DockerProcessIO
+from cli.blabot.blabot.docker_io import DockerExecIO
+from cli.blabot.blabot.docker_io import DockerRunIO
 from cli.blabot.blabot.process_io import ProcessIO
 
 START_COMMAND = "python3 /app/example.py"
+PROMPT = "> "
 DOCKER_IMAGE_NAME = "nn/example-app:latest"
 DOCKER_CONTAINER_NAME = "example_app"
 
 
 @pytest.fixture
 def docker_io_cli():
-    PROMPT = "> "
-    io_interact = DockerProcessIO(
+    docker_io = DockerRunIO(
         START_COMMAND,
         DOCKER_IMAGE_NAME,
         DOCKER_CONTAINER_NAME,
         prompt=PROMPT,
     )
 
-    docker_io_cli = ExampleCli(io_interact)
+    docker_io_cli = ExampleCli(docker_io)
     docker_io_cli.start()
     yield docker_io_cli
     docker_io_cli.stop()
@@ -43,12 +44,9 @@ def docker_io_exec_cli():
     res_ls = subprocess.run(docker_exec_command)
     assert res_ls.returncode == 0, "Failed to run docker sample command"
 
-    PROMPT = "> "
-    io_interact = DockerProcessIO(
+    io_interact = DockerExecIO(
         START_COMMAND,
-        DOCKER_IMAGE_NAME,
         DOCKER_CONTAINER_NAME,
-        True,
         prompt=PROMPT
     )
 


### PR DESCRIPTION
The class for docker corresponded to the pattern of using `docker run` and `docker exec` in one class, but was split into two classes to make it easier to understand.

#27