### PR TITLE
Add pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ __pycache__
 .pytest_cache
 
 bin/
+dist/
+poetry.lock
 venv*/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ graph LR
 
 ## Environment
 
+Please use either 1)poetry or 2)venv to build your environment.
+
+### 1) poetry
+
+```shell
+curl -sSL https://install.python-poetry.org | python3 -
+
+poetry install
+
+# Enter virtual environment
+poetry shell
+```
+
+### 2) venv
+
 ```shell
 # Install python environment
 ## e.g.) Linux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "blabot"
+version = "0.0.1"
+description = "A sample project that communicates interactively with CLI process"
+authors = [ "Nunoya Yuma <nuno.yu.3838@gmail.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+pexpect = "*"
+pexpect_serial = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+pytest-order = "*"
+
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Currently `venv` and `requirements.txt` were used to manage packages, but now it is also possible to use `poetry` and `pyproject.toml` to manage packages.

#38