### PR TITLE
Restore ruff rules: RET504, A002, TRY002, N806, ARG001

### DIFF
--- a/blabot/templated_io.py
+++ b/blabot/templated_io.py
@@ -82,7 +82,7 @@ class TemplatedIO(ABC):
             raise RuntimeError("Process not started")
 
         if self.wait_for_prompt() is False:
-            raise Exception("Prompt does not appear")
+            raise RuntimeError("Prompt does not appear")
 
         for _ in range(attempts):
             self.send_command(command)
@@ -97,8 +97,8 @@ class TemplatedIO(ABC):
         if self._prompt is None:
             return True
 
-        FIRST_TIMEOUT_SEC = 0.5
-        res = self.wait_for(self._prompt, FIRST_TIMEOUT_SEC)
+        first_timeout_sec = 0.5
+        res = self.wait_for(self._prompt, first_timeout_sec)
         if res == self._prompt:
             return True
 

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -19,15 +19,15 @@ class SampleCli:
             "off",
         )
 
-    def handle_input(self, input):
-        if input == "sample-status":
+    def handle_input(self, user_input):
+        if user_input == "sample-status":
             self._show_status()
-        elif input == "sample-ctrl on":
+        elif user_input == "sample-ctrl on":
             self._control_status("on")
-        elif input == "sample-ctrl off":
+        elif user_input == "sample-ctrl off":
             self._control_status("off")
         else:
-            sys.stderr.write(f"Invalid command: {input}\n")
+            sys.stderr.write(f"Invalid command: {user_input}\n")
             sys.stderr.flush()
 
     def _show_status(self):

--- a/examples/example_cli.py
+++ b/examples/example_cli.py
@@ -25,8 +25,7 @@ class ExampleCliBase:
             return None
 
         match = re.search(PATTERN, output)
-        res = match.group(1) if match else None
-        return res
+        return match.group(1) if match else None
 
     def send_on_off(self, command: str):
         PATTERN = "Sample status"

--- a/examples/example_cli.py
+++ b/examples/example_cli.py
@@ -18,18 +18,18 @@ class ExampleCliBase:
         return getattr(self._io_interact, name)
 
     def status_show(self):
-        PATTERN = "Sample status: (invalid|on|off)"
+        pattern = "Sample status: (invalid|on|off)"
 
-        output = self.run_command("sample-status", PATTERN)
+        output = self.run_command("sample-status", pattern)
         if output is None:
             return None
 
-        match = re.search(PATTERN, output)
+        match = re.search(pattern, output)
         return match.group(1) if match else None
 
     def send_on_off(self, command: str):
-        PATTERN = "Sample status"
-        return self.run_command(f"sample-ctrl {command}", PATTERN)
+        pattern = "Sample status"
+        return self.run_command(f"sample-ctrl {command}", pattern)
 
 
 class ExampleCli(ExampleCliBase):

--- a/examples/tests/test_device.py
+++ b/examples/tests/test_device.py
@@ -21,8 +21,8 @@ from examples.example_cli import ExampleCli
 
 @pytest.fixture
 def device_io_cli():
-    DEVICE_PORT = "/tmp/ttyV1"
-    io_interact = DeviceIO(DEVICE_PORT, prompt=EXAMPLE_PROMPT)
+    device_port = "/tmp/ttyV1"
+    io_interact = DeviceIO(device_port, prompt=EXAMPLE_PROMPT)
 
     device_io_cli = ExampleCli(io_interact)
     device_io_cli.start()

--- a/examples/tests/test_ssh.py
+++ b/examples/tests/test_ssh.py
@@ -44,9 +44,9 @@ def transfer_example(ssh_config):
 
 @pytest.fixture
 def ssh_io_cli(ssh_config):
-    START_COMMAND = "python3 /tmp/example_app.py"
+    start_command = "python3 /tmp/example_app.py"
     io_interact = SSHProcessIO(
-        START_COMMAND,
+        start_command,
         ssh_config["user_name"],
         ssh_config["host_name"],
         ssh_config["key_path"],

--- a/examples/tests/test_ssh.py
+++ b/examples/tests/test_ssh.py
@@ -60,5 +60,6 @@ def ssh_io_cli(ssh_config):
 
 
 @pytest.mark.ssh_test
-def test_ssh(ssh_config, transfer_example, ssh_io_cli):
+@pytest.mark.usefixtures("ssh_config", "transfer_example")
+def test_ssh(ssh_io_cli):
     ssh_io_cli.check_startup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ ignore = [
     "EM101",    # exception string literals - TODO: fix in separate PR
     "N802",     # function naming - TODO: fix in separate PR
     "S",        # security warnings - TODO: review in separate PR
-    "ARG001",   # unused arguments - TODO: review in separate PR
     "PT018",    # pytest assertion breakdown - TODO: review in separate PR
     "PLR0913",  # too many arguments - TODO: refactor in separate PR
     "FBT001",   # boolean positional argument - TODO: refactor in separate PR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ ignore = [
     "ANN",      # type annotations - TODO: add in separate PR
     "TRY003",   # exception message handling - TODO: fix in separate PR
     "EM101",    # exception string literals - TODO: fix in separate PR
-    "N806",     # variable naming - TODO: fix in separate PR
     "N802",     # function naming - TODO: fix in separate PR
     "S",        # security warnings - TODO: review in separate PR
     "ARG001",   # unused arguments - TODO: review in separate PR
@@ -42,7 +41,6 @@ ignore = [
     "PLR0913",  # too many arguments - TODO: refactor in separate PR
     "FBT001",   # boolean positional argument - TODO: refactor in separate PR
     "FBT002",   # boolean default positional argument - TODO: refactor in separate PR
-    "TRY002",   # create custom exception - TODO: fix in separate PR
     "COM812",   # trailing comma conflicts with formatter
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ ignore = [
     "FBT001",   # boolean positional argument - TODO: refactor in separate PR
     "FBT002",   # boolean default positional argument - TODO: refactor in separate PR
     "TRY002",   # create custom exception - TODO: fix in separate PR
-    "A002",     # shadowing builtin - TODO: fix in separate PR
-    "RET504",   # unnecessary assignment - TODO: fix in separate PR
     "COM812",   # trailing comma conflicts with formatter
 ]
 


### PR DESCRIPTION
## Summary
- Fix RET504: Remove unnecessary assignment in example_cli.py
- Fix A002: Rename 'input' parameter to avoid shadowing builtin
- Fix TRY002: Replace generic Exception with RuntimeError
- Fix N806: Convert UPPERCASE variables to lowercase in functions
- Fix ARG001: Use @pytest.mark.usefixtures for setup-only fixtures

## Test plan
- [x] All ruff checks pass
- [x] Code builds successfully
- [ ] Run relevant tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)