### PR TITLE
Restore ruff rules: EM101, TRY003, PT018

### DIFF
--- a/blabot/device_io.py
+++ b/blabot/device_io.py
@@ -29,7 +29,8 @@ class DeviceIO(TemplatedIO):
 
     def start(self):
         if self.process:
-            raise RuntimeError("Process has already started")
+            msg = "Process has already started"
+            raise RuntimeError(msg)
 
         if not self.device.is_open:
             self.device.open()
@@ -39,10 +40,12 @@ class DeviceIO(TemplatedIO):
 
     def stop(self):
         if not self.process:
-            raise RuntimeError("Process not started")
+            msg = "Process not started"
+            raise RuntimeError(msg)
 
         if not self.device.is_open:
-            raise RuntimeError("Device port is already closed")
+            msg = "Device port is already closed"
+            raise RuntimeError(msg)
 
         self.process.close()
         self.device.close()
@@ -50,14 +53,16 @@ class DeviceIO(TemplatedIO):
 
     def send_command(self, command: str) -> None:
         if not self.process:
-            raise RuntimeError("Process not started")
+            msg = "Process not started"
+            raise RuntimeError(msg)
 
         output_line = command + self._newline
         self.process.sendline(output_line)
 
     def wait_for(self, expect: str, timeout_sec: float = 3.0) -> str:
         if not self.process:
-            raise RuntimeError("Process not started")
+            msg = "Process not started"
+            raise RuntimeError(msg)
 
         expect_list = [
             pexpect.TIMEOUT,

--- a/blabot/docker_io.py
+++ b/blabot/docker_io.py
@@ -70,7 +70,8 @@ class DockerRunIO(DockerIOBase):
 
     def start(self):
         if self.process:
-            raise RuntimeError("Process has already started")
+            msg = "Process has already started"
+            raise RuntimeError(msg)
 
         docker_run_command = self._build_command()
         self._start_docker_and_process(docker_run_command)
@@ -115,7 +116,8 @@ class DockerExecIO(DockerIOBase):
 
     def start(self):
         if self.process:
-            raise RuntimeError("Process has already started")
+            msg = "Process has already started"
+            raise RuntimeError(msg)
 
         docker_exec_command = f"docker exec -it {self._docker_container_name} bash"
         self._start_docker_and_process(docker_exec_command)
@@ -127,7 +129,8 @@ class DockerExecIO(DockerIOBase):
             return
 
         if not self._docker_container_name:
-            raise RuntimeError("Container name is lost")
+            msg = "Container name is lost"
+            raise RuntimeError(msg)
 
         docker_remove_command = ["docker", "rm", "-f", self._docker_container_name]
         res_remove = subprocess.run(

--- a/blabot/process_io.py
+++ b/blabot/process_io.py
@@ -30,14 +30,16 @@ class ProcessIO(TemplatedIO):
 
     def start(self):
         if self.process:
-            raise RuntimeError("Process has already started")
+            msg = "Process has already started"
+            raise RuntimeError(msg)
 
         self.process = pexpect.spawn(self._start_command)
         self.process.logfile = sys.stdout.buffer
 
     def stop(self):
         if not self.process:
-            raise RuntimeError("Process not started")
+            msg = "Process not started"
+            raise RuntimeError(msg)
 
         self.process.terminate()
         self.process.wait()
@@ -49,7 +51,8 @@ class ProcessIO(TemplatedIO):
 
     def wait_for(self, expect: str, timeout_sec: float = 3.0) -> str:
         if not self.process:
-            raise RuntimeError("Process not started")
+            msg = "Process not started"
+            raise RuntimeError(msg)
 
         expect_list = [
             pexpect.TIMEOUT,

--- a/blabot/ssh_io.py
+++ b/blabot/ssh_io.py
@@ -22,7 +22,8 @@ class SSHProcessIO(ProcessIO):
 
     def start(self):
         if self.process:
-            raise RuntimeError("Process has already started")
+            msg = "Process has already started"
+            raise RuntimeError(msg)
 
         ssh_login_cmd = f"ssh -i {self._key_path} {self._user_name}@{self._host_name}"
         self.process = pexpect.spawn(ssh_login_cmd)

--- a/blabot/templated_io.py
+++ b/blabot/templated_io.py
@@ -79,10 +79,12 @@ class TemplatedIO(ABC):
         """
 
         if not self.process:
-            raise RuntimeError("Process not started")
+            msg = "Process not started"
+            raise RuntimeError(msg)
 
         if self.wait_for_prompt() is False:
-            raise RuntimeError("Prompt does not appear")
+            msg = "Prompt does not appear"
+            raise RuntimeError(msg)
 
         for _ in range(attempts):
             self.send_command(command)

--- a/examples/tests/test_ssh.py
+++ b/examples/tests/test_ssh.py
@@ -18,11 +18,15 @@ def ssh_config():
     ssh_config["host_name"] = os.environ.get("REMOTE_HOST_NAME")
     ssh_config["key_path"] = os.environ.get("REMOTE_KEY_PATH")
 
-    assert (
-        ssh_config["user_name"] is not None
-        and ssh_config["host_name"] is not None
-        and ssh_config["key_path"] is not None
-    ), "Set environment variables"
+    assert ssh_config["user_name"] is not None, (
+        "Set environment variable REMOTE_USER_NAME"
+    )
+    assert ssh_config["host_name"] is not None, (
+        "Set environment variable REMOTE_HOST_NAME"
+    )
+    assert ssh_config["key_path"] is not None, (
+        "Set environment variable REMOTE_KEY_PATH"
+    )
 
     return ssh_config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ ignore = [
     "ANN",      # type annotations - TODO: add in separate PR
     "N802",     # function naming - TODO: fix in separate PR
     "S",        # security warnings - TODO: review in separate PR
-    "PT018",    # pytest assertion breakdown - TODO: review in separate PR
     "PLR0913",  # too many arguments - TODO: refactor in separate PR
     "FBT001",   # boolean positional argument - TODO: refactor in separate PR
     "FBT002",   # boolean default positional argument - TODO: refactor in separate PR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ select = ["ALL"]
 ignore = [
     "D",        # pydocstyle - docstring requirements
     "ANN",      # type annotations - TODO: add in separate PR
-    "TRY003",   # exception message handling - TODO: fix in separate PR
-    "EM101",    # exception string literals - TODO: fix in separate PR
     "N802",     # function naming - TODO: fix in separate PR
     "S",        # security warnings - TODO: review in separate PR
     "PT018",    # pytest assertion breakdown - TODO: review in separate PR


### PR DESCRIPTION
## Summary
- Fix EM101: Convert exception string literals to variables (14 locations)
- Fix TRY003: Exception message handling automatically resolved by EM101 fixes
- Fix PT018: Break down complex assertion in test_ssh.py for better debugging

## Test plan
- [x] All ruff checks pass
- [x] Code builds successfully
- [ ] Run relevant tests to ensure no regressions

## Details
### EM101 (Exception string literals)
Converted all exception string literals to variables for better maintainability:
- device_io.py: 5 locations
- process_io.py: 3 locations  
- ssh_io.py: 1 location
- templated_io.py: 2 locations
- docker_io.py: 3 locations

### PT018 (Pytest assertion breakdown)
Split complex assertion in test_ssh.py into separate assertions with specific error messages for each environment variable.

🤖 Generated with [Claude Code](https://claude.ai/code)