### PR TITLE
Add comprehensive mypy support and CI/CD integration

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -8,16 +8,23 @@ on:
       - main
 
 jobs:
-  ruff_and_pytest:
+  lint_typecheck_and_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
       - name: Install dependencies for example tests
         run: |
           uv sync
@@ -26,6 +33,8 @@ jobs:
         run: uv run ruff format --check .
       - name: Lint code with ruff
         run: uv run ruff check .
+      - name: Type check with mypy
+        run: uv run mypy blabot/
 
       - name: Run example usage
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ uv run mypy blabot/
 
 ### Local CI Testing
 ```bash
-act -j ruff_and_pytest
+act -j lint_typecheck_and_test
 ```
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,14 @@ uv sync
 ### Testing
 ```bash
 # Run all tests
-pytest -v -s
+uv run pytest -v -s
 
 # Run specific test categories
-pytest -v -s -m "simple_process_test and easy" tests/
-pytest -v -s -m "simple_process_test and hard" tests/
-pytest -v -s -m "device_test" tests/
-pytest -v -s -m "docker_test" tests/
-pytest -v -s -m "ssh_test" tests/
+uv run pytest -v -s -m "simple_process_test and easy" tests/
+uv run pytest -v -s -m "simple_process_test and hard" tests/
+uv run pytest -v -s -m "device_test" tests/
+uv run pytest -v -s -m "docker_test" tests/
+uv run pytest -v -s -m "ssh_test" tests/
 
 # Docker-based testing
 docker compose build
@@ -40,6 +40,9 @@ pip install dist/blabot-0.1.0-py3-none-any.whl
 # Lint and format with ruff
 uv run ruff check .
 uv run ruff format .
+
+# Type checking with mypy
+uv run mypy blabot/
 ```
 
 ### Local CI Testing

--- a/blabot/device_io.py
+++ b/blabot/device_io.py
@@ -5,6 +5,7 @@ for communicating with serial devices such as USB-to-serial adapters.
 """
 
 import sys
+from typing import Any
 
 import pexpect
 import serial
@@ -125,10 +126,10 @@ class DeviceIO(TemplatedIO):
             msg = "Process not started"
             raise RuntimeError(msg)
 
-        expect_list = [
+        expect_list: list[Any] = [
             pexpect.TIMEOUT,
+            expect,
         ]
-        expect_list.append(expect)
         index = self.process.expect(expect_list, timeout=timeout_sec)
 
         match = None
@@ -136,7 +137,10 @@ class DeviceIO(TemplatedIO):
             # pexpect.TIMEOUT is output
             # This means that no matching string was output until the timeout.
             pass
-        else:
+        # process.after should be bytes when match is found
+        elif isinstance(self.process.after, bytes):
             match = self.process.after.decode("utf-8")
+        elif isinstance(self.process.after, str):
+            match = self.process.after
 
         return match

--- a/blabot/process_io.py
+++ b/blabot/process_io.py
@@ -5,6 +5,7 @@ for communicating with local processes using the pexpect library.
 """
 
 import sys
+from typing import Any
 
 import pexpect
 
@@ -114,10 +115,10 @@ class ProcessIO(TemplatedIO):
             msg = "Process not started"
             raise RuntimeError(msg)
 
-        expect_list = [
+        expect_list: list[Any] = [
             pexpect.TIMEOUT,
+            expect,
         ]
-        expect_list.append(expect)
         index = self.process.expect(expect_list, timeout=timeout_sec)
 
         match = None
@@ -125,7 +126,10 @@ class ProcessIO(TemplatedIO):
             # pexpect.TIMEOUT is output
             # This means that no matching string was output until the timeout.
             pass
-        else:
+        # process.after should be bytes when match is found
+        elif isinstance(self.process.after, bytes):
             match = self.process.after.decode("utf-8")
+        elif isinstance(self.process.after, str):
+            match = self.process.after
 
         return match

--- a/blabot/templated_io.py
+++ b/blabot/templated_io.py
@@ -120,7 +120,7 @@ class TemplatedIO(ABC):
 
         """
         # If prompt is not set, ignore it
-        if self._prompt is None:
+        if not self._prompt:
             return True
 
         first_timeout_sec = 0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dev-dependencies = [
     "pytest",
     "pytest-order",
     "ruff",
+    "mypy",
+    "types-pexpect",
+    "types-pyserial",
 ]
 
 [tool.ruff]
@@ -40,3 +43,35 @@ ignore = [
 "*/tests/*" = ["S101", "S108", "ANN", "D"]      # allow assert, temp files, skip type annotations and docstrings in nested test directories
 "examples/*" = ["S101", "S603", "S108", "ANN", "D"]  # allow assert, subprocess, temp files, skip type annotations and docstrings in example code
 "blabot/docker_io.py" = ["S603"]  # allow subprocess for docker commands
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+
+# Gradually enable strict mode
+disallow_any_generics = false  # Enable later
+disallow_subclassing_any = false  # Enable later
+
+# Per-module options
+[[tool.mypy.overrides]]
+module = "tests.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "examples.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "pexpect_serial"
+ignore_missing_imports = true

--- a/uv.lock
+++ b/uv.lock
@@ -13,9 +13,12 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-order" },
     { name = "ruff" },
+    { name = "types-pexpect" },
+    { name = "types-pyserial" },
 ]
 
 [package.metadata]
@@ -26,9 +29,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-order" },
     { name = "ruff" },
+    { name = "types-pexpect" },
+    { name = "types-pyserial" },
 ]
 
 [[package]]
@@ -50,12 +56,62 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/ea637422dedf0bf36f3ef238eab4e455e2a0dcc3082b5cc067615347ab8e/mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01", size = 3352570, upload_time = "2025-07-31T07:54:19.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/a2/7034d0d61af8098ec47902108553122baa0f438df8a713be860f7407c9e6/mypy-1.17.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:69e83ea6553a3ba79c08c6e15dbd9bfa912ec1e493bf75489ef93beb65209aeb", size = 11086295, upload_time = "2025-07-31T07:53:28.124Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1f/19e7e44b594d4b12f6ba8064dbe136505cec813549ca3e5191e40b1d3cc2/mypy-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b16708a66d38abb1e6b5702f5c2c87e133289da36f6a1d15f6a5221085c6403", size = 10112355, upload_time = "2025-07-31T07:53:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/69/baa33927e29e6b4c55d798a9d44db5d394072eef2bdc18c3e2048c9ed1e9/mypy-1.17.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89e972c0035e9e05823907ad5398c5a73b9f47a002b22359b177d40bdaee7056", size = 11875285, upload_time = "2025-07-31T07:53:55.293Z" },
+    { url = "https://files.pythonhosted.org/packages/90/13/f3a89c76b0a41e19490b01e7069713a30949d9a6c147289ee1521bcea245/mypy-1.17.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03b6d0ed2b188e35ee6d5c36b5580cffd6da23319991c49ab5556c023ccf1341", size = 12737895, upload_time = "2025-07-31T07:53:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/c4ee79ac484241301564072e6476c5a5be2590bc2e7bfd28220033d2ef8f/mypy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c837b896b37cd103570d776bda106eabb8737aa6dd4f248451aecf53030cdbeb", size = 12931025, upload_time = "2025-07-31T07:54:17.125Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b8/7409477be7919a0608900e6320b155c72caab4fef46427c5cc75f85edadd/mypy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:665afab0963a4b39dff7c1fa563cc8b11ecff7910206db4b2e64dd1ba25aed19", size = 9584664, upload_time = "2025-07-31T07:54:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/82/aec2fc9b9b149f372850291827537a508d6c4d3664b1750a324b91f71355/mypy-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93378d3203a5c0800c6b6d850ad2f19f7a3cdf1a3701d3416dbf128805c6a6a7", size = 11075338, upload_time = "2025-07-31T07:53:38.873Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ac/ee93fbde9d2242657128af8c86f5d917cd2887584cf948a8e3663d0cd737/mypy-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15d54056f7fe7a826d897789f53dd6377ec2ea8ba6f776dc83c2902b899fee81", size = 10113066, upload_time = "2025-07-31T07:54:14.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/946a1e0be93f17f7caa56c45844ec691ca153ee8b62f21eddda336a2d203/mypy-1.17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:209a58fed9987eccc20f2ca94afe7257a8f46eb5df1fb69958650973230f91e6", size = 11875473, upload_time = "2025-07-31T07:53:14.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0f/478b4dce1cb4f43cf0f0d00fba3030b21ca04a01b74d1cd272a528cf446f/mypy-1.17.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:099b9a5da47de9e2cb5165e581f158e854d9e19d2e96b6698c0d64de911dd849", size = 12744296, upload_time = "2025-07-31T07:53:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/70/afa5850176379d1b303f992a828de95fc14487429a7139a4e0bdd17a8279/mypy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ffadfbe6994d724c5a1bb6123a7d27dd68fc9c059561cd33b664a79578e14", size = 12914657, upload_time = "2025-07-31T07:54:08.576Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f9/4a83e1c856a3d9c8f6edaa4749a4864ee98486e9b9dbfbc93842891029c2/mypy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:9a2b7d9180aed171f033c9f2fc6c204c1245cf60b0cb61cf2e7acc24eea78e0a", size = 9593320, upload_time = "2025-07-31T07:53:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/38/56/79c2fac86da57c7d8c48622a05873eaab40b905096c33597462713f5af90/mypy-1.17.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:15a83369400454c41ed3a118e0cc58bd8123921a602f385cb6d6ea5df050c733", size = 11040037, upload_time = "2025-07-31T07:54:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c3/adabe6ff53638e3cad19e3547268482408323b1e68bf082c9119000cd049/mypy-1.17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:55b918670f692fc9fba55c3298d8a3beae295c5cded0a55dccdc5bbead814acd", size = 10131550, upload_time = "2025-07-31T07:53:41.307Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c5/2e234c22c3bdeb23a7817af57a58865a39753bde52c74e2c661ee0cfc640/mypy-1.17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62761474061feef6f720149d7ba876122007ddc64adff5ba6f374fda35a018a0", size = 11872963, upload_time = "2025-07-31T07:53:16.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/c13c130f35ca8caa5f2ceab68a247775648fdcd6c9a18f158825f2bc2410/mypy-1.17.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c49562d3d908fd49ed0938e5423daed8d407774a479b595b143a3d7f87cdae6a", size = 12710189, upload_time = "2025-07-31T07:54:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/c7d79d09f6de8383fe800521d066d877e54d30b4fb94281c262be2df84ef/mypy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:397fba5d7616a5bc60b45c7ed204717eaddc38f826e3645402c426057ead9a91", size = 12900322, upload_time = "2025-07-31T07:53:10.551Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/98/3d5a48978b4f708c55ae832619addc66d677f6dc59f3ebad71bae8285ca6/mypy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:9d6b20b97d373f41617bd0708fd46aa656059af57f2ef72aa8c7d6a2b73b74ed", size = 9751879, upload_time = "2025-07-31T07:52:56.683Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f3/8fcd2af0f5b806f6cf463efaffd3c9548a28f84220493ecd38d127b6b66d/mypy-1.17.1-py3-none-any.whl", hash = "sha256:a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9", size = 2283411, upload_time = "2025-07-31T07:53:24.664Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload_time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload_time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload_time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload_time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload_time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload_time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -170,4 +226,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/ef/b960ab4818f90ff59e571d03c3f992828d4683561095e80f9ef31f3d58b7/ruff-0.12.0-py3-none-win32.whl", hash = "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb", size = 10525289, upload_time = "2025-06-17T15:19:19.688Z" },
     { url = "https://files.pythonhosted.org/packages/34/93/8b16034d493ef958a500f17cda3496c63a537ce9d5a6479feec9558f1695/ruff-0.12.0-py3-none-win_amd64.whl", hash = "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0", size = 11598311, upload_time = "2025-06-17T15:19:21.785Z" },
     { url = "https://files.pythonhosted.org/packages/d0/33/4d3e79e4a84533d6cd526bfb42c020a23256ae5e4265d858bd1287831f7d/ruff-0.12.0-py3-none-win_arm64.whl", hash = "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b", size = 10724946, upload_time = "2025-06-17T15:19:23.952Z" },
+]
+
+[[package]]
+name = "types-pexpect"
+version = "4.9.0.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/a2/29564e69dee62f0f887ba7bfffa82fa4975504952e6199b218d3b403becd/types_pexpect-4.9.0.20250809.tar.gz", hash = "sha256:17a53c785b847c90d0be9149b00b0254e6e92c21cd856e853dac810ddb20101f", size = 13240, upload_time = "2025-08-09T03:15:04.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/1b/4d557287e6672feb749cf0d8ef5eb19189aff043e73e509e3775febc1cf1/types_pexpect-4.9.0.20250809-py3-none-any.whl", hash = "sha256:d19d206b8a7c282dac9376f26f072e036d22e9cf3e7d8eba3f477500b1f39101", size = 17039, upload_time = "2025-08-09T03:15:03.528Z" },
+]
+
+[[package]]
+name = "types-pyserial"
+version = "3.5.0.20250809"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/29/c28177639dab9f930bae5520c10955c702fd0d68c98daa0c2a709a9d031d/types_pyserial-3.5.0.20250809.tar.gz", hash = "sha256:19347ad22a97b3f99712bf97ce031f9ce4b8d94513f67426079bc7bfaae576c3", size = 19701, upload_time = "2025-08-09T03:16:03.689Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/55a2f13aee6b2811e0295cd587d9c2e1ae32cdff355f7fef1847072205b1/types_pyserial-3.5.0.20250809-py3-none-any.whl", hash = "sha256:d3355d97100883da1f9d14b3bcda191f158ad832e8c845dc3337fb5f2eb096fd", size = 25320, upload_time = "2025-08-09T03:16:02.686Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload_time = "2025-07-04T13:28:34.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload_time = "2025-07-04T13:28:32.743Z" },
 ]


### PR DESCRIPTION
## Summary
Complete implementation of mypy static type checking for blabot library with full CI/CD integration. This PR addresses issue #62 by introducing comprehensive type safety across the codebase.

## Key Features
- **Complete mypy setup** with balanced strictness configuration
- **Type stub integration** for external libraries (pexpect, pyserial)
- **CI/CD integration** with automated type checking
- **Enhanced developer experience** with improved IDE support

## Changes Made

### Dependencies & Configuration
- Add mypy, types-pexpect, types-pyserial to development dependencies
- Configure mypy with appropriate strictness for library development
- Add py.typed marker for type information export
- Exclude tests/examples from type checking requirements

### Type Safety Improvements
- Fix prompt type checking in templated_io.py (None vs empty string handling)
- Improve pexpect type handling in process_io.py and device_io.py
- Add proper type annotations for expect() method usage
- Handle process.after type variations (bytes vs str) safely

### CI/CD Enhancements
- Update Python version from 3.10 to 3.12 (matching project requirements)
- Add mypy type checking step to CI pipeline
- Implement uv dependency caching for faster builds
- Update job naming and documentation

### Developer Experience
- Add mypy commands to CLAUDE.md development workflow
- Maintain full compatibility with existing ruff linting
- Preserve all existing test functionality
- Enable better IDE support with type information

## Testing Results
- ✅ All 6 source files pass mypy with zero errors
- ✅ Full compatibility with ruff linting maintained
- ✅ All existing tests continue to pass
- ✅ Type safety enforced without breaking changes

## Benefits for Users
- **Enhanced IDE support**: Better autocomplete and error detection
- **Safer refactoring**: Type checking catches issues before runtime
- **Improved API clarity**: Method signatures are self-documenting
- **Better developer experience**: Clear type information for library users

## Closes
- Closes #62 (Introduce mypy for type checking)

🤖 Generated with [Claude Code](https://claude.ai/code)